### PR TITLE
맛집 목록 조회 Dto 추가 및 레스토랑 엔티티 수정

### DIFF
--- a/src/restaurants/dto/get-posts.dto.ts
+++ b/src/restaurants/dto/get-posts.dto.ts
@@ -1,0 +1,30 @@
+import { IsEnum, IsLatitude, IsLongitude, IsNotEmpty, IsOptional } from 'class-validator';
+import { RestaurantQueryOrder, RestaurantQueryOrderBy, RestaurantQueryRange } from '../enums/restaurant-query.enum';
+
+export class GetPostsDto {
+	@IsNotEmpty({ message: 'lat 필드는 필수 입력 필드입니다.' })
+	@IsLatitude({ message: 'lat 필드에 유효한 위도를 입력해야 합니다.' })
+	lat: number;
+
+	@IsNotEmpty({ message: 'lon 필드는 필수 입력 필드입니다.' })
+	@IsLongitude({ message: 'lon 필드에 유효한 경도를 입력해야 합니다.' })
+	lon: number;
+
+	@IsNotEmpty({ message: 'range 필드는 필수 입력 필드입니다.' })
+	@IsEnum(RestaurantQueryRange, {
+		message: `range 필드에 전달 가능한 값: [${RestaurantQueryRange.ONE_KM}, ${RestaurantQueryRange.FIVE_KM}, ${RestaurantQueryRange.TEN_KM}]`,
+	})
+	range: RestaurantQueryRange;
+
+	@IsOptional()
+	@IsEnum(RestaurantQueryOrderBy, {
+		message: `orderBy 필드에 전달 가능한 값: [${RestaurantQueryOrderBy.DIST}, ${RestaurantQueryOrderBy.RATING}]`,
+	})
+	orderBy: RestaurantQueryOrderBy = RestaurantQueryOrderBy.DIST; // default: dist
+
+	@IsOptional()
+	@IsEnum(RestaurantQueryOrder, {
+		message: `order 필드에 전달 가능한 값: [${RestaurantQueryOrder.DESC}, ${RestaurantQueryOrder.ASC}]`,
+	})
+	order: RestaurantQueryOrder = RestaurantQueryOrder.ASC; // default: asc
+}

--- a/src/restaurants/entity/restaurant.entity.ts
+++ b/src/restaurants/entity/restaurant.entity.ts
@@ -1,6 +1,7 @@
 import { BaseEntity } from 'src/global/entities/base.entity';
 import { Column, Entity } from 'typeorm';
-import { RestaurantCategory, RestaurantStatus } from '../enums/restaurant.enum';
+import { RestaurantCategory } from '../enums/restaurant.enum';
+import { BusinessState } from 'src/global/enums/business-state.enum';
 
 @Entity()
 export class Restaurant extends BaseEntity {
@@ -9,9 +10,9 @@ export class Restaurant extends BaseEntity {
 
 	@Column({
 		type: 'enum',
-		enum: RestaurantStatus,
+		enum: BusinessState,
 	})
-	status: RestaurantStatus;
+	status: BusinessState;
 
 	@Column({
 		type: 'numeric',
@@ -34,10 +35,13 @@ export class Restaurant extends BaseEntity {
 	rating: number;
 
 	@Column({
-		name: 'road_addr',
-		unique: true,
+		name: 'road_address',
+		comment: '도로명 주소',
 	})
-	roadAddr: string;
+	roadAddress: string;
+
+	@Column({ comment: '지번주소' })
+	address: string;
 
 	@Column({
 		type: 'enum',

--- a/src/restaurants/enums/restaurant-query.enum.ts
+++ b/src/restaurants/enums/restaurant-query.enum.ts
@@ -1,0 +1,15 @@
+export enum RestaurantQueryRange {
+	ONE_KM = '1.0',
+	FIVE_KM = '5.0',
+	TEN_KM = '10.0',
+}
+
+export enum RestaurantQueryOrderBy {
+	DIST = 'dist',
+	RATING = 'rating',
+}
+
+export enum RestaurantQueryOrder {
+	DESC = 'desc',
+	ASC = 'asc',
+}

--- a/src/restaurants/enums/restaurant.enum.ts
+++ b/src/restaurants/enums/restaurant.enum.ts
@@ -1,9 +1,5 @@
-export enum RestaurantStatus {
-	ON = '영업',
-}
-
 export enum RestaurantCategory {
-	CHINESE = '중국식',
+	CHINESE = '중식',
 	JAPANESE = '일식',
-	KIMBAP = '김밥(도시락)',
+	KOREAN = '한식',
 }

--- a/src/restaurants/restaurants.controller.ts
+++ b/src/restaurants/restaurants.controller.ts
@@ -1,13 +1,22 @@
-import { Controller, Get, Param, UseFilters } from '@nestjs/common';
+import { Controller, Get, Param, Query, UseFilters, UsePipes, ValidationPipe } from '@nestjs/common';
 import { RestaurantsService } from './restaurants.service';
 import { Restaurant } from './entity/restaurant.entity';
 import { HttpExceptionFilter } from 'src/global/filters/http-exception.filter';
 import { CustomParseUUIDPipe } from './pipes/custom-parse-uuid.pipe';
+import { GetPostsDto } from './dto/get-posts.dto';
 
 @Controller('restaurants')
 @UseFilters(HttpExceptionFilter)
 export class RestaurantsController {
 	constructor(private readonly restaurantsService: RestaurantsService) {}
+
+	@Get()
+	@UsePipes(
+		new ValidationPipe({ whitelist: true, transform: true, transformOptions: { enableImplicitConversion: true } }),
+	) // 임시 적용
+	getPosts(@Query() getPostsDto: GetPostsDto) {
+		console.log(getPostsDto);
+	}
 
 	@Get(':id')
 	findOne(@Param('id', CustomParseUUIDPipe) id: string): Promise<Restaurant> {


### PR DESCRIPTION
맛집 목록 조회 API에 사용할 Dto를 추가하였습니다.

레스토랑 엔티티를 수정하였습니다.
- roadAddress 수정
  - 유니크 제약조건 제거
  - 칼럼 이름 수정
- adress 추가
  - 지번 주소 칼럼