### PR TITLE
feat: 시군구 목록 조회 API

### DIFF
--- a/src/citys/citys.controller.ts
+++ b/src/citys/citys.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, UseFilters, UseGuards } from '@nestjs/common';
+import { CitysService } from './citys.service';
+import { City } from './entity/city.entity';
+import { AtGuard } from 'src/global/guard/access.token.quard';
+import { JwtExceptionFilter } from 'src/global/filters/jwt-exception.filter';
+
+@Controller('citys')
+@UseGuards(AtGuard)
+@UseFilters(JwtExceptionFilter)
+export class CitysController {
+	constructor(private readonly citysService: CitysService) {}
+
+	@Get()
+	getCities(): Promise<City[]> {
+		return this.citysService.getCities();
+	}
+}

--- a/src/citys/citys.module.ts
+++ b/src/citys/citys.module.ts
@@ -2,9 +2,11 @@ import { Module } from '@nestjs/common';
 import { CitysService } from './citys.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { City } from './entity/city.entity';
+import { CitysController } from './citys.controller';
 
 @Module({
 	imports: [TypeOrmModule.forFeature([City])],
+	controllers: [CitysController],
 	providers: [CitysService],
 })
 export class CitysModule {}

--- a/src/citys/citys.service.ts
+++ b/src/citys/citys.service.ts
@@ -54,4 +54,8 @@ export class CitysService implements OnModuleInit {
 			}
 		});
 	}
+
+	getCities(): Promise<City[]> {
+		return this.cityRepository.find();
+	}
 }


### PR DESCRIPTION
- CitysController 추가
- 컨트롤러 레벨에 AtGuard, JwtExceptionFilter 적용
- getCities 라우트 핸들러 추가(GET /citys)
- getCities 서비스 로직 추가
  - citys 테이블의 모든 레코드 반환(293개)

feat-#40